### PR TITLE
Fixes for checkerboard and concurrent access of solids-collection

### DIFF
--- a/src/carlvbn/raytracing/rendering/Scene.java
+++ b/src/carlvbn/raytracing/rendering/Scene.java
@@ -7,15 +7,17 @@ import carlvbn.raytracing.math.Ray;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class Scene {
     private Camera camera;
     private Light light;
-    private List<Solid> solids;
+    private CopyOnWriteArrayList<Solid> solids;
+    //private List<Solid> solids;
     private Skybox skybox;
 
     public Scene() {
-        this.solids = new ArrayList<Solid>();
+        this.solids = new CopyOnWriteArrayList<Solid>();
         this.camera = new Camera();
         this.light = new Light(new Vector3(-1, 2, -1));
         this.skybox = new Skybox("Sky.jpg");
@@ -31,7 +33,7 @@ public class Scene {
 
     public RayHit raycast(Ray ray) {
         RayHit closestHit = null;
-        for (Solid solid : solids.toArray(new Solid[0])) {
+        for (Solid solid : solids) { // .toArray(new Solid[0])) {
             if (solid == null)
                 continue;
 

--- a/src/carlvbn/raytracing/rendering/Scene.java
+++ b/src/carlvbn/raytracing/rendering/Scene.java
@@ -1,19 +1,16 @@
 package carlvbn.raytracing.rendering;
 
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import carlvbn.raytracing.math.Ray;
 import carlvbn.raytracing.math.RayHit;
 import carlvbn.raytracing.math.Vector3;
 import carlvbn.raytracing.solids.Solid;
-import carlvbn.raytracing.math.Ray;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public class Scene {
     private Camera camera;
     private Light light;
     private CopyOnWriteArrayList<Solid> solids;
-    //private List<Solid> solids;
     private Skybox skybox;
 
     public Scene() {
@@ -33,7 +30,7 @@ public class Scene {
 
     public RayHit raycast(Ray ray) {
         RayHit closestHit = null;
-        for (Solid solid : solids) { // .toArray(new Solid[0])) {
+        for (Solid solid : solids) {
             if (solid == null)
                 continue;
 

--- a/src/carlvbn/raytracing/solids/Plane.java
+++ b/src/carlvbn/raytracing/solids/Plane.java
@@ -31,13 +31,24 @@ public class Plane extends Solid {
     @Override
     public Color getTextureColor(Vector3 point) {
         if (checkerPattern) {
-            if ((int)point.getX() % 2 == 0 ^ (int)point.getZ() % 2 != 0) {
-                return Color.GRAY;
+            // in first or third quadrant of the checkerplane
+            if (((point.getX() > 0) & (point.getZ() > 0)) || ((point.getX() < 0) & (point.getZ() < 0))) {
+                if ((int)point.getX() % 2 == 0 ^ (int)point.getZ() % 2 != 0) {
+                    return Color.GRAY;
+                } else {
+                    return Color.DARK_GRAY;
+                }
             } else {
-                return Color.DARK_GRAY;
+                // in second or fourth quadrant of the checkerplane
+                if ((int)point.getX() % 2 == 0 ^ (int)point.getZ() % 2 != 0) {
+                    return Color.DARK_GRAY;
+                } else {
+                    return Color.GRAY;
+                }
             }
         } else {
             return getColor();
         }
     }
+
 }


### PR DESCRIPTION
Hi there

really great project! I would llike to supply two fixes:

* checkerboard pattern: was broken along the y-axis
* solids collection in `Scene`:  protect from concurrent access by both the `Renderer` and the `SettingsPanel` on Scene selection

Cheers